### PR TITLE
Fix WiFi AP mode fallback: restore auto-restart on first connection fail

### DIFF
--- a/src/SystemServices.cpp
+++ b/src/SystemServices.cpp
@@ -125,7 +125,9 @@ void SystemServices::failWifi()
         if (settingsManager.save())
         {
             logger.log("Failed to connect to wifi, reverted to AP mode (first connection attempt)");
-            logger.log("Please manually restart device to enter AP mode.");
+            logger.log("Restarting to enter AP mode...");
+            delay(1000);  // Give time for serial output
+            ESP.restart();
         }
         else
         {


### PR DESCRIPTION
…ailure

The SystemServices refactor accidentally removed the automatic restart when WiFi fails to connect on the first attempt. This broke the intended fallback behavior where the device would automatically enter AP mode without user intervention.

This restores the original behavior: when initial WiFi connection fails, the device sets ap_mode=true, saves settings, and automatically restarts. On reboot, it enters AP mode and allows users to configure WiFi credentials via the web UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WiFi failure handling: Device now automatically restarts when WiFi connection fails and Access Point mode is successfully activated, eliminating the need for manual restart.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->