### PR TITLE
Add Open Filament Sensor integration for Home Assistant

### DIFF
--- a/custom_components/open_filament_sensor
+++ b/custom_components/open_filament_sensor
@@ -1,0 +1,1 @@
+../extras/homeassistant/custom_components/open_filament_sensor

--- a/extras/homeassistant/custom_components/open_filament_sensor/__init__.py
+++ b/extras/homeassistant/custom_components/open_filament_sensor/__init__.py
@@ -1,0 +1,86 @@
+"""Open Filament Sensor integration for Home Assistant."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+
+import aiohttp
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Open Filament Sensor from a config entry."""
+    host = entry.data[CONF_HOST]
+
+    coordinator = OFSDataUpdateCoordinator(hass, host)
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+class OFSDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching OFS data."""
+
+    def __init__(self, hass: HomeAssistant, host: str) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=SCAN_INTERVAL),
+        )
+        self.host = host
+        self.session = async_get_clientsession(hass)
+        self._url = f"http://{host}/sensor_status"
+
+    async def _async_update_data(self) -> dict:
+        """Fetch data from OFS device."""
+        try:
+            async with asyncio.timeout(10):
+                async with self.session.get(self._url) as response:
+                    if response.status != 200:
+                        raise UpdateFailed(f"HTTP error {response.status}")
+                    data = await response.json()
+                    return data
+        except aiohttp.ClientError as err:
+            raise UpdateFailed(f"Error communicating with OFS: {err}") from err
+        except asyncio.TimeoutError as err:
+            raise UpdateFailed(f"Timeout communicating with OFS") from err
+
+    @property
+    def device_info(self) -> dict:
+        """Return device info for this OFS device."""
+        mac = self.data.get("mac", "unknown") if self.data else "unknown"
+        return {
+            "identifiers": {(DOMAIN, mac)},
+            "name": f"Open Filament Sensor ({self.host})",
+            "manufacturer": "OpenFilamentSensor",
+            "model": "ESP32 Filament Sensor",
+            "sw_version": "1.0",
+            "configuration_url": f"http://{self.host}",
+        }

--- a/extras/homeassistant/custom_components/open_filament_sensor/binary_sensor.py
+++ b/extras/homeassistant/custom_components/open_filament_sensor/binary_sensor.py
@@ -1,0 +1,111 @@
+"""Binary sensor platform for Open Filament Sensor integration."""
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import OFSDataUpdateCoordinator
+from .const import DOMAIN, BINARY_SENSORS
+
+
+# Map string device class names to actual classes
+DEVICE_CLASS_MAP = {
+    "problem": BinarySensorDeviceClass.PROBLEM,
+    "connectivity": BinarySensorDeviceClass.CONNECTIVITY,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up OFS binary sensors based on a config entry."""
+    coordinator: OFSDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+    for sensor_def in BINARY_SENSORS:
+        key, name, icon_on, icon_off, device_class_str, json_path = sensor_def
+        device_class = DEVICE_CLASS_MAP.get(device_class_str) if device_class_str else None
+        entities.append(
+            OFSBinarySensor(
+                coordinator=coordinator,
+                key=key,
+                name=name,
+                icon_on=icon_on,
+                icon_off=icon_off,
+                device_class=device_class,
+                json_path=json_path,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+def get_nested_value(data: dict, path: str):
+    """Get a value from nested dict using dot notation."""
+    if not data:
+        return None
+    keys = path.split(".")
+    value = data
+    for key in keys:
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            return None
+    return value
+
+
+class OFSBinarySensor(CoordinatorEntity[OFSDataUpdateCoordinator], BinarySensorEntity):
+    """Representation of an OFS binary sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: OFSDataUpdateCoordinator,
+        key: str,
+        name: str,
+        icon_on: str,
+        icon_off: str,
+        device_class: BinarySensorDeviceClass | None,
+        json_path: str,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self._key = key
+        self._json_path = json_path
+        self._icon_on = icon_on
+        self._icon_off = icon_off
+        self._attr_name = name
+        self._attr_device_class = device_class
+
+        # Create unique ID from MAC + sensor key
+        mac = coordinator.data.get("mac", "unknown") if coordinator.data else "unknown"
+        self._attr_unique_id = f"{mac}_{key}"
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return self.coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        value = get_nested_value(self.coordinator.data, self._json_path)
+        if value is None:
+            return None
+        return bool(value)
+
+    @property
+    def icon(self) -> str:
+        """Return the icon based on state."""
+        if self.is_on:
+            return self._icon_on
+        return self._icon_off

--- a/extras/homeassistant/custom_components/open_filament_sensor/config_flow.py
+++ b/extras/homeassistant/custom_components/open_filament_sensor/config_flow.py
@@ -1,0 +1,80 @@
+"""Config flow for Open Filament Sensor integration."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+    }
+)
+
+
+async def validate_input(hass, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+    session = async_get_clientsession(hass)
+    host = data[CONF_HOST]
+    url = f"http://{host}/sensor_status"
+
+    try:
+        async with asyncio.timeout(10):
+            async with session.get(url) as response:
+                if response.status != 200:
+                    raise CannotConnect(f"HTTP {response.status}")
+                json_data = await response.json()
+                # Get MAC for unique ID
+                mac = json_data.get("mac", "unknown")
+                return {"title": f"Open Filament Sensor ({host})", "mac": mac}
+    except aiohttp.ClientError as err:
+        raise CannotConnect(str(err)) from err
+    except asyncio.TimeoutError as err:
+        raise CannotConnect("Connection timeout") from err
+
+
+class OFSConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Open Filament Sensor."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                # Use MAC as unique ID to prevent duplicate entries
+                await self.async_set_unique_id(info["mac"])
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+
+class CannotConnect(Exception):
+    """Error to indicate we cannot connect."""

--- a/extras/homeassistant/custom_components/open_filament_sensor/const.py
+++ b/extras/homeassistant/custom_components/open_filament_sensor/const.py
@@ -1,0 +1,80 @@
+"""Constants for Open Filament Sensor integration."""
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfLength,
+    UnitOfTime,
+)
+
+DOMAIN = "open_filament_sensor"
+SCAN_INTERVAL = 5  # seconds
+
+# Sensor definitions: (key, name, unit, device_class, state_class, icon, json_path)
+# json_path is dot-notation: "elegoo.hardJamPercent" means data["elegoo"]["hardJamPercent"]
+SENSORS = [
+    # Jam Detection
+    ("hard_jam_percent", "Hard Jam", PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:alert-circle", "elegoo.hardJamPercent"),
+    ("soft_jam_percent", "Soft Jam", PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:alert", "elegoo.softJamPercent"),
+    ("grace_state", "Grace State", None, None, None, "mdi:timer-sand", "elegoo.graceState"),
+
+    # Filament Tracking
+    ("expected_filament", "Expected Filament", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.TOTAL_INCREASING, "mdi:printer-3d-nozzle", "elegoo.expectedFilament"),
+    ("actual_filament", "Actual Filament", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.TOTAL_INCREASING, "mdi:printer-3d-nozzle-outline", "elegoo.actualFilament"),
+    ("current_deficit", "Current Deficit", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.MEASUREMENT, "mdi:delta", "elegoo.currentDeficitMm"),
+    ("deficit_ratio", "Deficit Ratio", None, None, SensorStateClass.MEASUREMENT, "mdi:percent", "elegoo.deficitRatio"),
+    ("pass_ratio", "Pass Ratio", None, None, SensorStateClass.MEASUREMENT, "mdi:check-circle", "elegoo.passRatio"),
+    ("expected_rate", "Expected Rate", "mm/s", None, SensorStateClass.MEASUREMENT, "mdi:speedometer", "elegoo.expectedRateMmPerSec"),
+    ("actual_rate", "Actual Rate", "mm/s", None, SensorStateClass.MEASUREMENT, "mdi:speedometer-slow", "elegoo.actualRateMmPerSec"),
+
+    # Print Progress
+    ("print_status", "Print Status", None, None, None, "mdi:printer-3d", "elegoo.printStatus"),
+    ("current_layer", "Current Layer", None, None, SensorStateClass.MEASUREMENT, "mdi:layers", "elegoo.currentLayer"),
+    ("total_layers", "Total Layers", None, None, None, "mdi:layers-triple", "elegoo.totalLayer"),
+    ("progress", "Progress", PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:progress-check", "elegoo.progress"),
+    ("current_z", "Z Height", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.MEASUREMENT, "mdi:axis-z-arrow", "elegoo.currentZ"),
+    ("print_speed", "Print Speed", PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:speedometer", "elegoo.PrintSpeedPct"),
+
+    # Physical Sensors
+    ("movement_pulses", "Movement Pulses", None, None, SensorStateClass.TOTAL_INCREASING, "mdi:pulse", "elegoo.movementPulses"),
+
+    # Device Info
+    ("uptime", "Uptime", UnitOfTime.SECONDS, SensorDeviceClass.DURATION, SensorStateClass.TOTAL_INCREASING, "mdi:timer-outline", "uptimeSec"),
+    ("mainboard_id", "Mainboard ID", None, None, None, "mdi:identifier", "elegoo.mainboardID"),
+]
+
+# Binary sensor definitions: (key, name, icon_on, icon_off, device_class, json_path)
+BINARY_SENSORS = [
+    ("filament_stopped", "Filament Stopped", "mdi:alert-octagon", "mdi:check-circle", "problem", "stopped"),
+    ("filament_runout", "Filament Runout", "mdi:alert", "mdi:check-circle", "problem", "filamentRunout"),
+    ("printer_connected", "Printer Connected", "mdi:lan-connect", "mdi:lan-disconnect", "connectivity", "elegoo.isWebsocketConnected"),
+    ("is_printing", "Printing", "mdi:printer-3d-nozzle", "mdi:printer-3d-nozzle-off", None, "elegoo.isPrinting"),
+    ("grace_active", "Grace Active", "mdi:timer-sand", "mdi:timer-sand-empty", None, "elegoo.graceActive"),
+    ("telemetry_available", "Telemetry Available", "mdi:satellite-uplink", "mdi:satellite-variant", "connectivity", "elegoo.telemetryAvailable"),
+]
+
+# Print status mapping
+PRINT_STATUS_MAP = {
+    0: "Idle",
+    1: "Homing",
+    2: "Descending",
+    3: "Exposing",
+    4: "Lifting",
+    5: "Pausing",
+    6: "Paused",
+    7: "Stopping",
+    8: "Stopped",
+    9: "Complete",
+    10: "File Checking",
+    13: "Printing",
+    16: "Heating",
+    20: "Bed Leveling",
+}
+
+# Grace state mapping
+GRACE_STATE_MAP = {
+    0: "Idle",
+    1: "Start Grace",
+    2: "Resume Grace",
+    3: "Active",
+    4: "Jammed",
+}

--- a/extras/homeassistant/custom_components/open_filament_sensor/hacs.json
+++ b/extras/homeassistant/custom_components/open_filament_sensor/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Open Filament Sensor",
+  "render_readme": true,
+  "content_in_root": false,
+  "zip_release": false,
+  "filename": "open_filament_sensor"
+}

--- a/extras/homeassistant/custom_components/open_filament_sensor/manifest.json
+++ b/extras/homeassistant/custom_components/open_filament_sensor/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "open_filament_sensor",
+  "name": "Open Filament Sensor",
+  "codeowners": ["@harpua555"],
+  "config_flow": true,
+  "documentation": "https://github.com/harpua555/OpenFilamentSensor",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/harpua555/OpenFilamentSensor/issues",
+  "requirements": ["aiohttp"],
+  "version": "1.0.0"
+}

--- a/extras/homeassistant/custom_components/open_filament_sensor/sensor.py
+++ b/extras/homeassistant/custom_components/open_filament_sensor/sensor.py
@@ -1,0 +1,112 @@
+"""Sensor platform for Open Filament Sensor integration."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import OFSDataUpdateCoordinator
+from .const import DOMAIN, SENSORS, PRINT_STATUS_MAP, GRACE_STATE_MAP
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up OFS sensors based on a config entry."""
+    coordinator: OFSDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+    for sensor_def in SENSORS:
+        key, name, unit, device_class, state_class, icon, json_path = sensor_def
+        entities.append(
+            OFSSensor(
+                coordinator=coordinator,
+                key=key,
+                name=name,
+                unit=unit,
+                device_class=device_class,
+                state_class=state_class,
+                icon=icon,
+                json_path=json_path,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+def get_nested_value(data: dict, path: str):
+    """Get a value from nested dict using dot notation."""
+    if not data:
+        return None
+    keys = path.split(".")
+    value = data
+    for key in keys:
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            return None
+    return value
+
+
+class OFSSensor(CoordinatorEntity[OFSDataUpdateCoordinator], SensorEntity):
+    """Representation of an OFS sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: OFSDataUpdateCoordinator,
+        key: str,
+        name: str,
+        unit: str | None,
+        device_class: str | None,
+        state_class: str | None,
+        icon: str,
+        json_path: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._key = key
+        self._json_path = json_path
+        self._attr_name = name
+        self._attr_native_unit_of_measurement = unit
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
+        self._attr_icon = icon
+
+        # Create unique ID from MAC + sensor key
+        mac = coordinator.data.get("mac", "unknown") if coordinator.data else "unknown"
+        self._attr_unique_id = f"{mac}_{key}"
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return self.coordinator.device_info
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        value = get_nested_value(self.coordinator.data, self._json_path)
+
+        # Map numeric status values to human-readable strings
+        if self._key == "print_status" and value is not None:
+            return PRINT_STATUS_MAP.get(value, f"Unknown ({value})")
+        if self._key == "grace_state" and value is not None:
+            return GRACE_STATE_MAP.get(value, f"Unknown ({value})")
+
+        # Round floating point values for cleaner display
+        if isinstance(value, float):
+            if self._key in ("hard_jam_percent", "soft_jam_percent", "progress", "print_speed"):
+                return round(value, 1)
+            if self._key in ("expected_filament", "actual_filament", "current_deficit"):
+                return round(value, 2)
+            if self._key in ("deficit_ratio", "pass_ratio"):
+                return round(value, 3)
+            if self._key in ("expected_rate", "actual_rate"):
+                return round(value, 2)
+
+        return value

--- a/extras/homeassistant/custom_components/open_filament_sensor/strings.json
+++ b/extras/homeassistant/custom_components/open_filament_sensor/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Open Filament Sensor",
+        "description": "Enter the IP address or hostname of your Open Filament Sensor device.",
+        "data": {
+          "host": "Host"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to device. Check the IP address and ensure the device is powered on.",
+      "unknown": "An unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "This device is already configured."
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Filament Sensor integration for Home Assistant with comprehensive monitoring capabilities including filament status, print progress tracking, physical sensor data, jam detection, and device information. Includes automatic device discovery, periodic local polling for updates, and intuitive UI-based setup requiring only the device's network host address.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->