### PR TITLE
chore(esp32c6) Adding support for ESP32-C6 boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Connect your BigTreeTech Smart Filament Sensor (or generic motion/runout sensor)
 
 | Board Type | Runout Signal Pin | Motion Signal Pin |
 | :--- | :--- | :--- |
-| **Generic ESP32 / ESP32-S3** | GPIO 12 | GPIO 13 |
+| **Generic ESP32 / ESP32-S3** | GPIO 14 | GPIO 27 |
 | **Seeed XIAO ESP32-S3** | GPIO 5 | GPIO 6 |
 | **Seeed XIAO ESP32-C3** | GPIO 3 | GPIO 2 |
 | **ESP32-C3 SuperMini** | GPIO 3 | GPIO 2 |
+| **Seeed XIAO ESP32-C6** | GPIO 21 | GPIO 2 |
+| **ESP32-C6 DevKitC-1** | GPIO 2 | GPIO 3 |
+| **ESP32-C6 DevKitM-1** | GPIO 2 | GPIO 3 |
 
 *Note: Pins can be customized in `platformio.ini` or by rebuilding firmware if needed.*
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,31 +16,31 @@ monitor_speed = 115200
 
 [common]
 framework = arduino
-platform = espressif32
+platform = espressif32 @ 6.12.0 ; Setting a version to ensure older boards use the older arduino framework if built after a newer board using pioarduino
 lib_deps =
-	esp32async/AsyncTCP@3.4.9
-	ayushsharma82/ElegantOTA@^3.1.0
-	bblanchon/ArduinoJson @ 6.19.4
-	esp32async/ESPAsyncWebServer@3.9.3
-	links2004/WebSockets@^2.6.1
-	robtillaart/UUID@^0.2.0
-	; OLED display libraries (only linked when ENABLE_OLED_DISPLAY=1)
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit GFX Library@^1.11.9
+    esp32async/AsyncTCP@3.4.9
+    ayushsharma82/ElegantOTA@^3.1.0
+    bblanchon/ArduinoJson @ 6.19.4
+    esp32async/ESPAsyncWebServer@3.9.3
+    links2004/WebSockets@^2.6.1
+    robtillaart/UUID@^0.2.0
+    ; OLED display libraries (only linked when ENABLE_OLED_DISPLAY=1)
+    adafruit/Adafruit SSD1306@^2.5.7
+    adafruit/Adafruit GFX Library@^1.11.9
 build_flags =
-	-D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
-	; -D FILAMENT_RUNOUT_PIN=12
-	; -D MOVEMENT_SENSOR_PIN=13
-	; -D INVERT_RUNOUT_PIN=1  ; Uncomment in board config if pin logic is inverted
-	; Coredump configuration - saves crash info to flash partition for analysis
+    -D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
+    ; -D FILAMENT_RUNOUT_PIN=12
+    ; -D MOVEMENT_SENSOR_PIN=13
+    ; -D INVERT_RUNOUT_PIN=1  ; Uncomment in board config if pin logic is inverted
+    ; Coredump configuration - saves crash info to flash partition for analysis
     ; -D CONFIG_APP_REPRODUCIBLE_BUILD=y  ; commented out because 
     ;   Firmware ThumbprintFilesystemThumbprint,Project Status
     ;   and Version displayed in the WebUI about tab might depend on them
-	-D CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=1
-	-D CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=1
-	-D CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=1
-	; Crash testing endpoint (/api/panic) and UI section. Disable for release builds.
-	; -D ENABLE_CRASH_TESTING=1
+-D CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=1
+-D CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=1
+-D CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=1
+; Crash testing endpoint (/api/panic) and UI section. Disable for release builds.
+; -D ENABLE_CRASH_TESTING=1
 extra_scripts =
 	pre:tools/set_build_timestamp.py
 
@@ -53,13 +53,13 @@ board_build.filesystem = littlefs
 build_flags =
     ${common.build_flags}
     -D FILAMENT_RUNOUT_PIN=14
-	-D MOVEMENT_SENSOR_PIN=27
+    -D MOVEMENT_SENSOR_PIN=27
 lib_deps =
-		${common.lib_deps}
+    ${common.lib_deps}
 extra_scripts =
-	${common.extra_scripts}
-	post:tools/merge_bin.py
-
+    ${common.extra_scripts}
+    post:tools/merge_bin.py
+    
 [env:esp32s3]
 board = esp32-s3-devkitc-1
 platform = ${common.platform}
@@ -70,10 +70,10 @@ build_flags =
     ${common.build_flags}
     ; -D INVERT_RUNOUT_PIN=1  ; Uncomment if this board needs inverted runout pin logic
 lib_deps =
-		${common.lib_deps}
+    ${common.lib_deps}
 extra_scripts =
-	${common.extra_scripts}
-	post:tools/merge_bin.py
+    ${common.extra_scripts}
+    post:tools/merge_bin.py
 
 [env:seeed_esp32s3]
 board = seeed_xiao_esp32s3
@@ -82,13 +82,13 @@ framework = ${common.framework}
 board_build.filesystem = littlefs
 build_flags =
     ${common.build_flags}
-		-D FILAMENT_RUNOUT_PIN=5
-		-D MOVEMENT_SENSOR_PIN=6
+    -D FILAMENT_RUNOUT_PIN=5
+    -D MOVEMENT_SENSOR_PIN=6
 lib_deps =
-		${common.lib_deps}
+    ${common.lib_deps}
 extra_scripts =
-	${common.extra_scripts}
-	post:tools/merge_bin.py
+    ${common.extra_scripts}
+    post:tools/merge_bin.py
 
 [env:seeed_esp32c3]
 ; Seeed XIAO ESP32-C3 with OTA support
@@ -115,10 +115,10 @@ build_unflags =
     -O2
     -O3
 lib_deps =
-        ${common.lib_deps}
+    ${common.lib_deps}
 extra_scripts =
-	${common.extra_scripts}
-	post:tools/merge_bin.py
+    ${common.extra_scripts}
+    post:tools/merge_bin.py
 
 [env:esp32c3]
 ; ESP32-C3 SuperMini with OTA support
@@ -169,6 +169,95 @@ extra_scripts =
      -D OLED_SCL_PIN=6
      -D OLED_DISPLAY_MODE=5
 extends = env:esp32c3
+
+[env:esp32c6]
+board = esp32-c6-devkitc-1
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
+; esp32c6 boards require arduino 3.x that is not supported by platformio, so pioarduino is required
+framework = ${common.framework}
+lib_compat_mode = strict
+board_build.filesystem = littlefs
+board_build.partitions = boards/partitions_c3_ota.csv
+build_flags =
+    ${common.build_flags}
+    -D FILAMENT_RUNOUT_PIN=2
+    -D MOVEMENT_SENSOR_PIN=3
+    ; -D INVERT_RUNOUT_PIN=1  ; Uncomment if this board needs inverted runout pin logic
+    -Os
+    -D CORE_DEBUG_LEVEL=0
+    -fno-exceptions
+    -ffunction-sections
+    -fdata-sections
+    -Wl,--gc-sections
+build_unflags =
+    -O2
+    -O3    
+lib_deps =
+    ${common.lib_deps}
+lib_ignore = 
+    WebServer ; arduino 3.x has its own synchrnous WebServer implementation that must be removed
+extra_scripts =
+	${common.extra_scripts}
+	post:tools/merge_bin.py
+
+[env:esp32c6m]
+board = esp32-c6-devkitm-1
+platform = ${env:esp32c6.platform}
+framework = ${common.framework}
+lib_compat_mode = strict
+board_build.filesystem = littlefs
+board_build.partitions = boards/partitions_c3_ota.csv
+build_flags =
+    ${common.build_flags}
+    -D FILAMENT_RUNOUT_PIN=2
+    -D MOVEMENT_SENSOR_PIN=3
+    ; -D INVERT_RUNOUT_PIN=1  ; Uncomment if this board needs inverted runout pin logic
+    -Os
+    -D CORE_DEBUG_LEVEL=0
+    -fno-exceptions
+    -ffunction-sections
+    -fdata-sections
+    -Wl,--gc-sections
+build_unflags =
+    -O2
+    -O3
+lib_deps =
+    ${common.lib_deps}
+lib_ignore =
+    ${env:esp32c6.lib_ignore}
+extra_scripts =
+    ${common.extra_scripts}
+    post:tools/merge_bin.py
+
+[env:seeed_esp32c6]
+board = seeed_xiao_esp32c6
+platform = ${env:esp32c6.platform}
+framework = ${common.framework}
+lib_compat_mode = strict
+board_build.filesystem = littlefs
+board_build.partitions = boards/partitions_c3_ota.csv
+build_flags =
+    ${common.build_flags}
+    -D FILAMENT_RUNOUT_PIN=21   ; Adjust based on your wiring
+    -D MOVEMENT_SENSOR_PIN=2   ; Adjust based on your wiring
+    ; -D INVERT_RUNOUT_PIN=1   ; Removed - sensor outputs HIGH when filament is present
+    -Os
+    -D CORE_DEBUG_LEVEL=0
+    -fno-exceptions
+    -ffunction-sections
+    -fdata-sections
+    -Wl,--gc-sections
+build_unflags =
+    -O2
+    -O3
+lib_deps =
+    ${common.lib_deps}
+lib_ignore =
+    ${env:esp32c6.lib_ignore}
+extra_scripts =
+	${common.extra_scripts}
+	post:tools/merge_bin.py
+
 
 [env:native]
 platform = native

--- a/tools/board_config.py
+++ b/tools/board_config.py
@@ -17,6 +17,9 @@ BOARD_TO_CHIP_FAMILY: Dict[str, str] = {
     "seeed_esp32s3": "Seeed ESP32-S3",
     "seeed_esp32c3": "Seeed ESP32-C3",
     "esp32c3supermini": "ESP32-C3",
+    "seeed_esp32c6": "Seeed ESP32-C6",
+    "esp32c6": "ESP32-C6 DevKitC-1",
+    "esp32c6m": "ESP32-C6 DevKitM-1",
 }
 
 def get_chip_family_for_board(board_env: str) -> str:

--- a/tools/build-targets.yml
+++ b/tools/build-targets.yml
@@ -8,3 +8,6 @@ platformio_envs:
   - seeed_esp32s3        # active (Seeed XIAO ESP32-S3)
   - esp32c3              # active (ESP32-C3 SuperMini)
   - esp32c3supermini     # alternate env for the ESP32-C3 SuperMini packaging
+  - esp32c6              # active (ESP32-C6-DevKitC1)
+  - esp32c6m             # active (ESP32-C6-DevKitM1)
+  - seeed_esp32c6        # active (Seeed XIAO ESP32-C6)

--- a/tools/build_and_release.py
+++ b/tools/build_and_release.py
@@ -124,6 +124,9 @@ BOARD_TO_DISTRIBUTOR_DIR = {
     "seeed_esp32s3": "seeed_esp32s3",
     "seeed_esp32c3": "seeed_esp32c3",
     "esp32c3supermini": "esp32c3supermini",
+    "seeed_esp32c6": "seeed_esp32c6",
+    "esp32c6": "esp32c6",
+    "esp32c6m": "esp32c6m",    
 }
 
 ALL_ENVIRONMENT = "all"

--- a/tools/tools-launcher.ps1
+++ b/tools/tools-launcher.ps1
@@ -66,6 +66,9 @@ $BuildEnvOptions = @(
     "esp32",
     "seeed_esp32s3",
     "seeed_esp32c3",
+    "seeed_esp32c6",
+    "esp32c6",
+    "esp32c6m",    
     "<enter manually>"
 )
 

--- a/tools/tools-launcher.py
+++ b/tools/tools-launcher.py
@@ -66,6 +66,9 @@ BUILD_ENV_OPTIONS = [
     "esp32",
     "seeed_esp32s3",
     "seeed_esp32c3",
+    "seeed_esp32c6",
+    "esp32c6",
+    "esp32c6m",
 ]
 
 RELEASE_ENV_OPTIONS = BUILD_ENV_OPTIONS + ["all"]


### PR DESCRIPTION
Adding support for ESP32-C6 boards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32‑C6 variants: Seeed XIAO ESP32‑C6, ESP32‑C6 DevKitC‑1, ESP32‑C6 DevKitM‑1.
  * CI/build targets and tooling updated to include these ESP32‑C6 variants.

* **Updates**
  * Updated Generic ESP32 / ESP32‑S3 Runout/Motion pin mapping (now Runout GPIO14 / Motion GPIO27).
  * Platform version pinned to improve build consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->